### PR TITLE
check title.length

### DIFF
--- a/lib/logic.js
+++ b/lib/logic.js
@@ -56,6 +56,8 @@ let logic = function(data) {
                 postStr.splice(2,0,'#+ABBRLINK: ' + abbrlink)
                 fs.writeFileSync(data.full_source, postStr.join('\n'), 'utf-8');
             }
+            if(data.title.length==0)
+                log.i("No title found for post [%s]", data.slug);
             log.i("Generate link %s for post [%s]", abbrlink, data.title);
         }
         model.add(abbrlink);


### PR DESCRIPTION
`title.length` should not be zero.

If there is no title, it should be better to log the full path of that file, in order to alert the user.

Demo for no title: https://blog.eson.org/pub/0/