### PR TITLE
change: Code cleanup & Calc abbrlink in post_permalink & Remove unrelated features

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,8 @@
 
 var hexo = hexo || {};
 
-hexo.extend.filter.register('before_post_render', require('./lib/logic'), 15);
+let generator = require('./lib/logic')
+
+// ensure to be firstly executed
+hexo.extend.filter.register('post_permalink', generator.generateAbbrlink, 1);
+hexo.extend.filter.register('before_post_render', generator.writebackToFiles, 1);

--- a/lib/logic.js
+++ b/lib/logic.js
@@ -1,13 +1,17 @@
 'use strict';
 
-var crc16 = require('./crc16');
-var crc32 = require('./crc32');
-var model = require('./model');
-var front = require('hexo-front-matter');
-var fs = require('hexo-fs');
+let crc16 = require('./crc16');
+let crc32 = require('./crc32');
+let model = require('./model');
+let front = require('hexo-front-matter');
+let fs = require('hexo-fs');
+
+function is_org_mode_file(filepath) {
+    return /.*\.org/.test(filepath)
+}
 
 function org_get_abbrlink(data) {
-    var r = data.content.match(/#\+ABBRLINK:.*\n/);
+    let r = data.content.match(/#\+ABBRLINK:.*\n/);
     if (r) {
         data.abbrlink = r[0].split(':')[1].trim();
     } else {
@@ -16,122 +20,46 @@ function org_get_abbrlink(data) {
     return data;
 }
 
-let logic = function (data) {
-    var log = this.log;
+let generateAbbrlink = function (data) {
+    let log = this.log;
     const config = this.config.abbrlink || {};
-    //+++ Draft processing
-    var opt_drafts = this.config.abbrlink && this.config.abbrlink.drafts ? this.config.abbrlink.drafts : false;
-    if (opt_drafts == false) {
-        if (!this.config.render_drafts && data.source.startsWith('_drafts/')) return data;
+
+    // Draft processing
+    let opt_drafts = config && config.drafts ? config.drafts : false;
+    if (opt_drafts == false && data.source.startsWith('_drafts/')) {
+            return data;
     }
-    //+++
+    // only calc for posts
     if (data.layout == 'post') {
         let abbrlink;
-        if (!/.*\.org/.test(data.source)) {
+        if (!is_org_mode_file(data.source)) {
             abbrlink = data.abbrlink;
         } else {
             abbrlink = org_get_abbrlink(data).abbrlink;
         }
-        // if (!abbrlink || abbrlink == '0' || config.force) {
-        let root_path = data.source.startsWith('_drafts/') ? 'source/_drafts' : 'source/_posts'
 
-        //re parse front matter
-        var tmpPost = front.parse(data.raw);
+        // re-parse front matter
+        let front_matter = front.parse(data.raw);
 
-        // ------ auto title ?
-        if (this.config.abbrlink && this.config.abbrlink.auto_title && !tmpPost.title) {
-            // maybe the title is path/to/something.md
-            // so we split / first and split . again
-            const pathParts = data.source.split('/');
-            let last = pathParts[pathParts.length - 1];
-            let last2 = pathParts[pathParts.length - 2];
-
-            const endPort2 = last2.lastIndexOf('.');
-            var last2tail = ''
-            var last2front = ''
-            if (endPort2 > -1) {
-                last2tail = last2.substring(endPort2 + 1);
-                last2front = last2.substring(0, endPort2);
-            }
-            if (last2tail == 'textbundle'){
-                tmpPost.title = last2front;
-            } else {
-                const endPort = last.indexOf('.');
-                if (endPort > -1) {
-                    last = last.substring(0, endPort);
-                }
-                tmpPost.title = last;
-            }
-            if (data.title.length == 0)
-                log.i('No title [%s] in post [ %s ]', data.title, data.full_source);
-            log.i('Generated: title [%s] for post [ %s ]', tmpPost.title, data.full_source);
-        }
-
-        // ----- auto date ? easy
-        if (this.config.abbrlink && this.config.abbrlink.auto_date && !tmpPost.date) {
-            tmpPost.date = data.date.format('YYYY-MM-DD HH:mm:ss');
-            log.i('Generated: date [%s] for post [ %s ]', tmpPost.date, data.full_source);
-        }
-
-        //From: hexo-auto-category
-        //see:https://github.com/xu-song/hexo-auto-category
-        //File: hexo-auto-category\lib\logic.js
-        var opt_AutoCategoryEnable = config.auto_category && config.auto_category.enable;
-        var overwrite = config.auto_category && config.auto_category.over_write;
-        if (opt_AutoCategoryEnable && overwrite) {
-            var categories = data.source.split('/');
-
-            if (categories.length - 2 >= 0) {
-                let last2 = categories[categories.length - 2];
-                const endPort2 = last2.lastIndexOf('.');
-                var last2tail = ''
-                var last2front = ''
-                if (endPort2 > -1) {
-                    last2tail = last2.substring(endPort2 + 1);
-                    last2front = last2.substring(0, endPort2);
-                }
-                if (last2tail == 'textbundle'){
-                    categories.pop();
-                }
-            }
-
-            var opt_AutoCategoryDepth = config.auto_category.depth || 3;
-            var depth = opt_AutoCategoryDepth || categories.length - 2;
-            if (categories.length - 2 == 0 || depth == 0) {
-                tmpPost.categories = this.config.default_category;
-            } else {
-                var newCategories = categories.slice(1, 1 + Math.min(depth, categories.length - 2));
-                //prevents duplicate file changes
-                if (
-                    !Array.isArray(tmpPost.categories) ||
-                    tmpPost.categories.join('_') != newCategories.join('_')
-                ) {
-                    tmpPost.categories = newCategories;
-                    log.i('Generated: categories [%s] for post [ %s ]', tmpPost.categories, data.full_source);
-                }
-            }
-        }
-
-        //add new generated link
+        // calc abbrlinks
         if (!abbrlink || abbrlink == '0' || config.force) {
-            var opt_alg = this.config.abbrlink && this.config.abbrlink.alg ? this.config.abbrlink.alg : 'crc16';
-            var opt_rep = this.config.abbrlink && this.config.abbrlink.rep ? this.config.abbrlink.rep : 'dec';
-            let res = opt_alg == 'crc32' ? crc32.str(tmpPost.title + tmpPost.date) >>> 0 : crc16(tmpPost.title + tmpPost.date) >>> 0;
-            //check this abbrlink is already exist then get a different one
-            abbrlink = model.check(res);
-            //set abbrlink to hex or dec
-            abbrlink = opt_rep == 'hex' ? abbrlink.toString(16) : abbrlink;
+            let opt_alg = config && config.alg ? config.alg : 'crc16';
+            let opt_rep = config && config.rep ? config.rep : 'dec';
+            let abbrlink_value = opt_alg == 'crc32' ? crc32.str(front_matter.title + front_matter.date) >>> 0 : crc16(front_matter.title + front_matter.date) >>> 0;
+            // if this abbrlink already exists, choose a different one
+            abbrlink_value = model.check(abbrlink_value);
+            model.add(abbrlink_value);
+            // generate actual abbrlink string
+            abbrlink = opt_rep == 'hex' ? abbrlink_value.toString(16) : abbrlink_value;
             data.abbrlink = abbrlink;
-            tmpPost.abbrlink = abbrlink;
-            log.i('Generated: link [%s] for post [ %s ]', tmpPost.abbrlink, data.full_source);
+            front_matter.abbrlink = abbrlink;
+            log.i('Generated: link [%s] for post [ %s ]', front_matter.abbrlink, data.full_source);
         }
-        let abbrlink_int = opt_rep == 'hex' ? parseInt('0x'+abbrlink) : abbrlink
-        model.add(abbrlink_int);
 
         let postStr;
-        if (!/.*\.org/.test(data.source)) {
-            //process post
-            postStr = front.stringify(tmpPost);
+        if (!is_org_mode_file(data.source)) {
+            // process post
+            postStr = front.stringify(front_matter);
             postStr = '---\n' + postStr;
             fs.writeFileSync(data.full_source, postStr, 'utf-8');
         } else {
@@ -139,9 +67,8 @@ let logic = function (data) {
             postStr.splice(2, 0, '#+ABBRLINK: ' + abbrlink);
             fs.writeFileSync(data.full_source, postStr.join('\n'), 'utf-8');
         }
-
     }
     return data;
 };
 
-module.exports = logic;
+module.exports = generateAbbrlink;

--- a/lib/logic.js
+++ b/lib/logic.js
@@ -20,6 +20,8 @@ function org_get_abbrlink(data) {
     return data;
 }
 
+let abbrlinkCache = {}
+
 let generateAbbrlink = function (data) {
     let log = this.log;
     const config = this.config.abbrlink || {};
@@ -52,23 +54,40 @@ let generateAbbrlink = function (data) {
             // generate actual abbrlink string
             abbrlink = opt_rep == 'hex' ? abbrlink_value.toString(16) : abbrlink_value;
             data.abbrlink = abbrlink;
-            front_matter.abbrlink = abbrlink;
-            log.i('Generated: link [%s] for post [ %s ]', front_matter.abbrlink, data.full_source);
-        }
-
-        let postStr;
-        if (!is_org_mode_file(data.source)) {
-            // process post
-            postStr = front.stringify(front_matter);
-            postStr = '---\n' + postStr;
-            fs.writeFileSync(data.full_source, postStr, 'utf-8');
-        } else {
-            postStr = data.raw.split('\n');
-            postStr.splice(2, 0, '#+ABBRLINK: ' + abbrlink);
-            fs.writeFileSync(data.full_source, postStr.join('\n'), 'utf-8');
+            abbrlinkCache[data.source] = abbrlink
+            log.i('Generated: link [%s] for post [ %s ]', data.abbrlink, data.full_source);
         }
     }
     return data;
 };
 
-module.exports = generateAbbrlink;
+let writebackToFiles = function (data) {
+    let opt_writeback = this.config.abbrlink && this.config.abbrlink.writeback != undefined ? this.config.abbrlink.writeback : true;
+    if(!opt_writeback)
+        return data;
+
+    // avoid rewrite front-matter if the same abbrlink exists
+    let abbrlink = abbrlinkCache[data.source]
+    if(!abbrlink)
+        return data;
+    let front_matter = front.parse(data.raw);
+    if (front_matter.abbrlink == abbrlink)
+        return data;
+
+    front_matter.abbrlink = abbrlink;
+    if (!is_org_mode_file(data.source)) {
+        // process post
+        let postStr = front.stringify(front_matter);
+        postStr = '---\n' + postStr;
+        fs.writeFileSync(data.full_source, postStr, 'utf-8');
+    } else {
+        let postStr = data.raw.split('\n');
+        postStr.splice(2, 0, '#+ABBRLINK: ' + abbrlink);
+        fs.writeFileSync(data.full_source, postStr.join('\n'), 'utf-8');
+    }
+}
+
+module.exports = {
+    generateAbbrlink,
+    writebackToFiles
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,20 +1,17 @@
 'use strict';
 
-var crcRes = [];
+var crcCache = [];
 
-let checKCrc = function(res) {
-    if (crcRes.indexOf(res) > -1) {
+let checkCrc = function(res) {
+    while (crcCache.indexOf(res) > -1) {
         res++;
-        return checKCrc(res);
-    } else {
-        return res;
     }
-
+    return res;
 }
 
 let thisAdd = function(value) {
-    crcRes.push(value);
+    crcCache.push(value);
 }
 
 exports.add = thisAdd;
-exports.check = checKCrc;
+exports.check = checkCrc;


### PR DESCRIPTION
### Changes: 
- Code cleanup
- Calc abbrlink in `post_permalink`, and write back to file in `before_post_render`, to provide compatibility for more other plugins (Related to #73)
- Remove features unrelated to abbrlink-generation. 
  - In fact, it's not a good idea to integrate too many unrelated features into this project, which will make it hard to maintain. 
  - As an example, `auto-catetory` seems to be not working. We can use [zthxxx/hexo-directory-category](https://github.com/zthxxx/hexo-directory-category) as an alternative.