### PR TITLE
 fix: ensure that each post should only be processed once

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,28 +28,16 @@ permalink: posts/:abbrlink/
 permalink: posts/:abbrlink.html
 ```
 
-There are two settings:
-
-```
-alg -- Algorithm (currently support crc16 and crc32, which crc16 is default)
-rep -- Represent (the generated link could be presented in hex or dec value)
-```
+Configs in `_config.yml`:
 
 ```
 # abbrlink config
 abbrlink:
-  alg: crc32      #support crc16(default) and crc32
-  rep: hex        #support dec(default) and hex
-  drafts: false   #(true)Process draft,(false)Do not process draft. false(default) 
-  # Generate categories from directory-tree
-  # depth: the max_depth of directory-tree you want to generate, should > 0
-  auto_category:
-     enable: true  #true(default)
-     depth:        #3(default)
-     over_write: false 
-  auto_title: false #enable auto title, it can auto fill the title by path
-  auto_date: false #enable auto date, it can auto fill the date by time today
-  force: false #enable force mode,in this mode, the plugin will ignore the cache, and calc the abbrlink for every post even it already had abbrlink. This only updates abbrlink rather than other front variables.
+  alg: crc32      # Algorithm used to calc abbrlink. Support crc16(default) and crc32
+  rep: hex        # Representation of abbrlink in URLs. Support dec(default) and hex
+  drafts: false   # Whether to generate abbrlink for drafts. (false in default)
+  force: false    # Enable force mode. In this mode, the plugin will ignore the cache, and calc the abbrlink for every post even it already had an abbrlink. (false in default)
+  writeback: true # Whether to write changes to front-matters back to the actual markdown files. (true in default)
 ```
 
 ## Sample
@@ -72,8 +60,6 @@ crc32 & dec
 https://post.zz173.com/posts/1690090958.html
 ```
 
-## Limitation
-[fixed] Maximum number of posts is 65535 for crc16. (now, if a abbrlink already exist, it will change another one and try again and again...) 
 ## More info
 
 see [this](https://post.zz173.com/detail/hexo-abbrlink.html)(Chinese)

--- a/lib/logic.js
+++ b/lib/logic.js
@@ -20,17 +20,21 @@ function org_get_abbrlink(data) {
     return data;
 }
 
-let abbrlinkCache = {}
-
 let generateAbbrlink = function (data) {
     let log = this.log;
     const config = this.config.abbrlink || {};
 
-    // Draft processing
+    // draft processing
     let opt_drafts = config && config.drafts ? config.drafts : false;
     if (opt_drafts == false && data.source.startsWith('_drafts/')) {
             return data;
     }
+    // ensure that each post should only be processed once
+    if (model.isPostProcessed(data.source)) {
+        data.abbrlink = model.getPostAbbrlink(data.source)
+        return data;
+    }
+
     // only calc for posts
     if (data.layout == 'post') {
         let abbrlink;
@@ -49,12 +53,12 @@ let generateAbbrlink = function (data) {
             let opt_rep = config && config.rep ? config.rep : 'dec';
             let abbrlink_value = opt_alg == 'crc32' ? crc32.str(front_matter.title + front_matter.date) >>> 0 : crc16(front_matter.title + front_matter.date) >>> 0;
             // if this abbrlink already exists, choose a different one
-            abbrlink_value = model.check(abbrlink_value);
-            model.add(abbrlink_value);
+            abbrlink_value = model.uniqueAbbrlink(abbrlink_value);
             // generate actual abbrlink string
             abbrlink = opt_rep == 'hex' ? abbrlink_value.toString(16) : abbrlink_value;
             data.abbrlink = abbrlink;
-            abbrlinkCache[data.source] = abbrlink
+
+            model.cachePostAbbrlink(data.source, abbrlink)
             log.i('Generated: link [%s] for post [ %s ]', data.abbrlink, data.full_source);
         }
     }
@@ -67,7 +71,7 @@ let writebackToFiles = function (data) {
         return data;
 
     // avoid rewrite front-matter if the same abbrlink exists
-    let abbrlink = abbrlinkCache[data.source]
+    let abbrlink = model.getPostAbbrlink(data.source)
     if(!abbrlink)
         return data;
     let front_matter = front.parse(data.raw);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,17 +1,29 @@
 'use strict';
 
-var crcCache = [];
+var crcCache = new Set();
+var postAbbrlinkCache = new Map();
 
-let checkCrc = function(res) {
-    while (crcCache.indexOf(res) > -1) {
+// ensure that every Abbrlink is unique
+let uniqueCrc = function(res) {
+    while (crcCache.has(res)) {
         res++;
     }
+    crcCache.add(res);
     return res;
 }
+exports.uniqueAbbrlink = uniqueCrc;
 
-let thisAdd = function(value) {
-    crcCache.push(value);
+
+// post abbrlink cache
+let isPostProcessed = function(postPath) {
+    return postAbbrlinkCache.has(postPath);
 }
-
-exports.add = thisAdd;
-exports.check = checkCrc;
+let cachePostAbbrlink = function(postPath, abbrlink) {
+    postAbbrlinkCache.set(postPath, abbrlink);
+}
+let getPostAbbrlink = function(postPath) {
+    return postAbbrlinkCache.get(postPath);
+}
+exports.isPostProcessed = isPostProcessed;
+exports.cachePostAbbrlink = cachePostAbbrlink;
+exports.getPostAbbrlink = getPostAbbrlink;


### PR DESCRIPTION
- Fix a serious bug: When used with certain plugins, sometimes `post_permalink` is called more than once, causing `abbrlink` to be incorrect. 
  - Now ensure that each post is only processed once.
- Move `abbrlink` cache to `model`, make the logic clearer.
- Update README with current configurations.